### PR TITLE
Correct the property to `clouds_low`

### DIFF
--- a/weatherbit/models.py
+++ b/weatherbit/models.py
@@ -202,7 +202,7 @@ class Point(UnicodeMixin):
         self.clouds = point.get('clouds')
         self.clouds_hi = point.get('clouds_hi')
         self.clouds_mid = point.get('clouds_mid')
-        self.clouds_lo = point.get('clouds_lo')
+        self.clouds_low = point.get('clouds_low')
 
     def _get_date_from_timestamp(self, datestamp, is_date=False):
         date_format = "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
The property named `clouds_lo` here is actually named `clouds_low`
See https://www.weatherbit.io/api/weather-forecast-hourly and https://www.weatherbit.io/api/weather-forecast-16-day
Trying to retrieve `clouds_lo` gave `None` results otherwise...